### PR TITLE
Fixes #11 Composer prevents install

### DIFF
--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -17,6 +17,12 @@ namespace Cultiv.Hangfire
         public void Compose(IUmbracoBuilder builder)
         {
             var connectionString = GetConnectionString(builder);
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                // This might happen when the package is installed before Umbraco is installed
+                // https://github.com/nul800sebastiaan/Cultiv.Hangfire/issues/11
+                return;
+            }
             
             // Configure Hangfire to use our current database and add the option to write console messages
             builder.Services.AddHangfire(configuration =>


### PR DESCRIPTION
This at least makes sure the Umbraco installer can run (see #11) but you'd have to stop and start the site to get the Hangfire installer to run after that.

Fixes #11 