### PR TITLE
Ignore AntiForgeryToken

### DIFF
--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -64,7 +64,7 @@ public class HangfireComposer : IComposer
                 {
                     endpoints.MapHangfireDashboardWithAuthorizationPolicy(
                         pattern: Constants.System.Endpoint,
-                        options: new DashboardOptions() { IgnoreAntiforgeryToken = true },
+                        options: new DashboardOptions { IgnoreAntiforgeryToken = true },
                         authorizationPolicyName: AuthorizationPolicies.SectionAccessSettings);
                 })
             });

--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -64,7 +64,7 @@ public class HangfireComposer : IComposer
                 {
                     endpoints.MapHangfireDashboardWithAuthorizationPolicy(
                         pattern: Constants.System.Endpoint,
-                        options: new DashboardOptions(),
+                        options: new DashboardOptions() { IgnoreAntiforgeryToken = true },
                         authorizationPolicyName: AuthorizationPolicies.SectionAccessSettings);
                 })
             });


### PR DESCRIPTION
This is a suggestion based on multiple [issues](https://github.com/HangfireIO/Hangfire/issues/1248) surrounding situations where you have load balanced environments or other scenarios causing the following error: `System.Security.Cryptography.CryptographicException: The key {0b722c3b-499f-4fc5-a4cc-f70f94b007f8} was not found in the key ring.`

Setting `IgnoreAntiforgeryToken = true` removes the error (obviously).
The M$ suggested resolution is to sync the data protection folders across instances which might not always be feasible (plus it still doesn't work for me). 

Since this plugin already puts the dashboard behind Umbraco authentication I figure this can be left out.