### PR TITLE
Makes SqlServerStorage configurable

### DIFF
--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Hangfire;
+﻿using Hangfire;
 using Hangfire.Console;
 using Hangfire.Dashboard;
 using Hangfire.SqlServer;
@@ -8,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
@@ -87,13 +87,13 @@ public class HangfireComposer : IComposer
                 .UseConsole()
                 .UseSqlServerStorage((Func<SqlConnection>)ConnectionFactory, new SqlServerStorageOptions
                 {
-                    PrepareSchemaIfNecessary = true,
-                    EnableHeavyMigrations = true,
-                    CommandBatchMaxTimeout = TimeSpan.FromMinutes(5),
-                    SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
-                    QueuePollInterval = TimeSpan.Zero,
-                    UseRecommendedIsolationLevel = true,
-                    DisableGlobalLocks = true
+                    PrepareSchemaIfNecessary = settings.StorageOptions.PrepareSchemaIfNecessary,
+                    EnableHeavyMigrations = settings.StorageOptions.EnableHeavyMigrations,
+                    CommandBatchMaxTimeout = settings.StorageOptions.CommandBatchMaxTimeout,
+                    SlidingInvisibilityTimeout = settings.StorageOptions.SlidingInvisibilityTimeout,
+                    QueuePollInterval = settings.StorageOptions.QueuePollInterval,
+                    UseRecommendedIsolationLevel = settings.StorageOptions.UseRecommendedIsolationLevel,
+                    DisableGlobalLocks = settings.StorageOptions.DisableGlobalLocks
                 });
         });
 

--- a/Cultiv.Hangfire/HangfireSettings.cs
+++ b/Cultiv.Hangfire/HangfireSettings.cs
@@ -1,11 +1,25 @@
-﻿namespace Cultiv.Hangfire;
+﻿using System;
+
+namespace Cultiv.Hangfire;
 
 public class HangfireSettings
 {
     public Server Server { get; set; }
+    public StorageOptions StorageOptions { get; set; } = new StorageOptions();
 }
 
 public class Server
 {
-    public bool? Disabled { get; set; } 
+    public bool? Disabled { get; set; }
+}
+
+public class StorageOptions
+{
+    public bool PrepareSchemaIfNecessary { get; set; } = true;
+    public bool EnableHeavyMigrations { get; set; } = true;
+    public TimeSpan CommandBatchMaxTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan SlidingInvisibilityTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan QueuePollInterval { get; set; } = TimeSpan.Zero;
+    public bool UseRecommendedIsolationLevel { get; set; } = true;
+    public bool DisableGlobalLocks { get; set; } = true;
 }


### PR DESCRIPTION
We had a project where Hangfire was stampeding the database with millions of queries for polling the queue. We fixed it somehow, by doing our own build of your package, where we changed the SqlServerStorage options (setting QueuePollInterval to 15 seconds).

I thought it would be nice if we could incorporate the ability to configure these things in the package. So heres a PR :)