### PR TITLE
Disable hangfire

### DIFF
--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Hangfire;
+﻿using Hangfire;
 using Hangfire.Console;
 using Hangfire.Dashboard;
 using Hangfire.SqlServer;
@@ -8,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
@@ -26,7 +26,10 @@ public class HangfireComposer : IComposer
         {
             serverDisabled = settings.Server.Disabled.GetValueOrDefault(defaultValue: false);
         }
-
+        if (serverDisabled)
+        {
+            return
+        }
         builder.ManifestFilters().Append<ManifestFilter>();
 
         var provider = builder.Config.GetConnectionStringProviderName(Umbraco.Cms.Core.Constants.System.UmbracoConnectionName);

--- a/Cultiv.Hangfire/HangfireComposer.cs
+++ b/Cultiv.Hangfire/HangfireComposer.cs
@@ -28,7 +28,7 @@ public class HangfireComposer : IComposer
         }
         if (serverDisabled)
         {
-            return
+            return;
         }
         builder.ManifestFilters().Append<ManifestFilter>();
 
@@ -52,11 +52,9 @@ public class HangfireComposer : IComposer
                     .UseConsole();
             });
 
-            if (!serverDisabled)
-            {
-                // Run the required server so your queued jobs will get executed
-                builder.Services.AddHangfireServer();
-            }
+            // Run the required server so your queued jobs will get executed
+            builder.Services.AddHangfireServer();
+
 
             AddAuthorizedUmbracoDashboard(builder);
 
@@ -100,11 +98,8 @@ public class HangfireComposer : IComposer
                 });
         });
 
-        if (!serverDisabled)
-        {
-            // Run the required server so your queued jobs will get executed
-            builder.Services.AddHangfireServer();
-        }
+        // Run the required server so your queued jobs will get executed
+        builder.Services.AddHangfireServer();
 
         AddAuthorizedUmbracoDashboard(builder);
         // For some reason we need to give it the connection string again, else we get this error:


### PR DESCRIPTION
If the disabled flag is set, this should be honoured with no code run. For example if the code is installed against the front end or a readonly database.