### PR TITLE
Fixed /stats auth issue

### DIFF
--- a/Cultiv.Hangfire/Constants.cs
+++ b/Cultiv.Hangfire/Constants.cs
@@ -5,7 +5,7 @@
         public static class CultivHangfire
         {
             public const string HangfireDashboard = nameof(HangfireDashboard);
-            public const string Endpoint = "/umbraco/hangfire";
+            public const string Endpoint = "/cultiv/hangfire";
             public const string AlternativeConnectionStringName = "hangfireDB";
             
             public const string CookiesScheme = "Cultiv.Hangfire.CookieScheme";

--- a/Cultiv.Hangfire/wwwroot/App_Plugins/Cultiv.Hangfire/dashboard-element.js
+++ b/Cultiv.Hangfire/wwwroot/App_Plugins/Cultiv.Hangfire/dashboard-element.js
@@ -13,7 +13,7 @@ template.innerHTML = `
             </style>
 
             <uui-box class="hangfire-wrapper">                
-                <iframe name="hangfireIframe" class="hangfire-content" id="Hangfire" src="/umbraco/hangfire/"></iframe>
+                <iframe name="hangfireIframe" class="hangfire-content" id="Hangfire" src="/cultiv/hangfire/"></iframe>
             </uui-box>
 `;
 


### PR DESCRIPTION
Fixes #39 

I have fixed the issue with the backoffice endpoints not always working correctly.

I have done this by moving the endpoints from /umbraco/hangfire to /cultiv/hangfire

There seems to be something within the ajax requests which gets blocked when running under the /umbraco path