### PR TITLE
Fix Hangfire dashboard tab breaking on Umbraco 17.5.0 (provideContext error)

### DIFF
--- a/Cultiv.Hangfire/wwwroot/App_Plugins/Cultiv.Hangfire/dashboard-element.js
+++ b/Cultiv.Hangfire/wwwroot/App_Plugins/Cultiv.Hangfire/dashboard-element.js
@@ -1,3 +1,5 @@
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+
 const template = document.createElement('template');
 template.innerHTML = `
             <style>           
@@ -18,7 +20,7 @@ template.innerHTML = `
 `;
 
 
-export default class CultivHangfireDashboardElement extends HTMLElement {
+export default class CultivHangfireDashboardElement extends UmbElementMixin(HTMLElement) {
 
     constructor() {
         super();


### PR DESCRIPTION
> [!NOTE]
> Claude over explaining with its PR description
> TL:DR version ensure dashboard webcomponent uses UmbElementMixin to avoid bug

## Summary
- Fixes #57 — the Hangfire dashboard tab throws `TypeError: t.provideContext is not a function` and fails to render on Umbraco 17.5.0.
- Umbraco 17.5.0 ([umbraco/Umbraco-CMS@d40c959](https://github.com/umbraco/Umbraco-CMS/commit/d40c959be7f8f95140492ce6c9105be264758f64), [umbraco/Umbraco-CMS#22517](https://github.com/umbraco/Umbraco-CMS/pull/22517)) made the section-main-view route `setup()` unconditionally call `context.provideAt(component)` on every dashboard/section-view element, which requires the element to implement `provideContext` (only available via `UmbElementMixin`). That mixin was intentionally dropped in 948030b back when nothing in the element consumed Umbraco context — reasonable at the time, but 17.5.0 now requires it regardless.
- Restores `UmbElementMixin(HTMLElement)` on `CultivHangfireDashboardElement`, matching what the element had before 948030b. This is the only change needed; the same `dashboard-element.js` also backs the optional `sectionView` ("own section") registration in `umbraco-package.json`, so this fixes both entry points.

## Test plan
- [x] Verified locally against Umbraco.Cms 17.5.0: Settings > Hangfire tab loads without console errors and the dashboard iframe renders.
- [x] Maintainer to confirm on their own 17.4.x/17.5.x setups that nothing regresses.
