### PR TITLE
Fix Hangfire dashboard 401 on Umbraco 18

### DIFF
--- a/Cultiv.Hangfire/Cultiv.Hangfire.csproj
+++ b/Cultiv.Hangfire/Cultiv.Hangfire.csproj
@@ -24,9 +24,9 @@
 
     <ItemGroup>
 		<!-- Next lines specifies that you need at least v17.0.0 installed to be able to install this package -->
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0, 18.0.0)" />
-		<PackageReference Include="Umbraco.Cms.Persistence.SqlServer" Version="[17.0.0, 18.0.0)" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0, 18.0.0)" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0, 19.0.0)" />
+		<PackageReference Include="Umbraco.Cms.Persistence.SqlServer" Version="[17.0.0, 19.0.0)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0, 19.0.0)" />
         <PackageReference Include="Hangfire" Version="1.8.23" />
         <PackageReference Include="Hangfire.Console" Version="1.4.3" />
         <PackageReference Include="Hangfire.Storage.SQLite" Version="0.4.3" />

--- a/Cultiv.Hangfire/OpenIddictServerEventsHandler.cs
+++ b/Cultiv.Hangfire/OpenIddictServerEventsHandler.cs
@@ -1,10 +1,12 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenIddict.Server;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Cultiv.Hangfire;
@@ -45,13 +47,11 @@ public class OpenIddictServerEventsHandler :
         }
         
         // only proceed if user has access to the Settings section
-        if (!context.Principal.HasClaim(c => 
-                c.Issuer == Umbraco.Cms.Core.Constants.Security.BackOfficeAuthenticationType
-                && c.Value == Umbraco.Cms.Core.Constants.Applications.Settings))
+        if (!await HasSettingsAccessAsync(context.Principal))
         {
             return;
         }
-        
+
         // create a new principal with the claims from the authenticated principal 
         var principal = new ClaimsPrincipal(
             new ClaimsIdentity(
@@ -64,6 +64,40 @@ public class OpenIddictServerEventsHandler :
         await _httpContextAccessor
             .GetRequiredHttpContext()
             .SignInAsync(Constants.CultivHangfire.CookiesScheme, principal, GetAuthenticationProperties());
+    }
+
+    // determine whether the signed-in back-office user has access to the Settings section
+    private async Task<bool> HasSettingsAccessAsync(ClaimsPrincipal principal)
+    {
+        // Umbraco < 18 exposed the user's allowed sections as claims on the back-office
+        // identity (issuer == BackOfficeAuthenticationType, value == section alias), so
+        // honour those directly when present.
+        if (principal.HasClaim(c =>
+                c.Issuer == Umbraco.Cms.Core.Constants.Security.BackOfficeAuthenticationType
+                && c.Value == Umbraco.Cms.Core.Constants.Applications.Settings))
+        {
+            return true;
+        }
+
+        // Umbraco 18 stopped adding allowed-application claims to the token, so fall back
+        // to resolving the user's allowed sections from the user service.
+        var userService = _httpContextAccessor
+            .GetRequiredHttpContext()
+            .RequestServices
+            .GetService<IUserService>();
+        if (userService is null)
+        {
+            return false;
+        }
+
+        var subject = principal.FindFirstValue(Umbraco.Cms.Core.Constants.Security.OpenIdDictSubClaimType);
+        if (!Guid.TryParse(subject, out var userKey))
+        {
+            return false;
+        }
+
+        var user = await userService.GetAsync(userKey);
+        return user?.AllowedSections.Contains(Umbraco.Cms.Core.Constants.Applications.Settings) == true;
     }
 
     // event handler for when access tokens are revoked


### PR DESCRIPTION
## Problem

On **Umbraco 18** the Hangfire dashboard at `/cultiv/hangfire` returns **401 Unauthorized** for every user, even a logged-in admin with Settings access:

```
GET /cultiv/hangfire/ 401 (Unauthorized)
```

## Root cause

The dashboard has no login of its own — its authorization filter only checks `AuthenticateAsync("Cultiv.Hangfire.CookieScheme")`. That cookie is issued by `OpenIddictServerEventsHandler.HandleAsync(GenerateTokenContext)`, gated on the principal carrying an *allowed-application* claim whose value is the `settings` section alias:

```csharp
context.Principal.HasClaim(c =>
    c.Issuer == Constants.Security.BackOfficeAuthenticationType
    && c.Value == Constants.Applications.Settings)
```

**Umbraco 18 stopped putting those claims on the back-office identity.** Confirmed by decompiling `Umbraco.Core`:

- `Constants.Security.AllowedApplicationsClaimType` (`.../backoffice/allowedapp`) **exists in 17.x, removed in 18.x** (along with `StartContentNodeIdClaimType` / `StartMediaNodeIdClaimType`).
- `BackOfficeIdentityBuilderExtensions.AddRequiredClaims` iterated `allowedApps` and added one claim per section in 17.x; in 18.x that loop is gone and the `allowedApps` parameter is unused.

With the claim absent, the gate never passes, the cookie is never issued, and the dashboard 401s. This affects all Umbraco 18 users, not just external/UmbracoId logins (that was just how it first surfaced).

## Fix

`OpenIddictServerEventsHandler` now:

1. **Fast path (Umbraco < 18):** keep the existing allowed-application claim check.
2. **Fallback (Umbraco 18+):** when the claim is absent, resolve the user by the token's `sub` (user key) via `IUserService` and check `IUser.AllowedSections.Contains("settings")`.

`IUserService` is resolved from `HttpContext.RequestServices` (scoped) rather than constructor-injected into this singleton handler, avoiding a captive dependency.

Also widened the Umbraco dependency range from `[17.0.0, 18.0.0)` to `[17.0.0, 19.0.0)` so the package installs on 18 (removes the NU1608 downgrade warning).

## Verification

- Builds cleanly (0 errors) against both Umbraco `17.0.0` and `18.0.2`.
- Uses only APIs present in both majors (`IUserService.GetAsync(Guid)`, `IUser.AllowedSections`, `Constants.Security.OpenIdDictSubClaimType`, `BackOfficeAuthenticationType`, `Applications.Settings`), so the single code path serves both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)